### PR TITLE
fix: work when canvas is disabled

### DIFF
--- a/Macros.js
+++ b/Macros.js
@@ -151,7 +151,7 @@ class FurnaceMacros {
 		else {
 			context.speaker = ChatMessage.getSpeaker();
 			context.actor = (args && typeof args[0] === "object") ? args[0].actor : game.actors.get(context.speaker.actor);
-			context.token = (args && typeof args[0] === "object") ? args[0].token : canvas.tokens.get(context.speaker.token);
+			context.token = (args && typeof args[0] === "object") ? args[0].token : canvas.tokens?.get(context.speaker.token);
 			context.character = game.user.character;
 		}
 		return context;


### PR DESCRIPTION
Without this, no macros can be used if the canvas is disabled (e.g. when no scenes are active)